### PR TITLE
Composable verbose names

### DIFF
--- a/composite_field/base.py
+++ b/composite_field/base.py
@@ -66,6 +66,17 @@ class CompositeField(object, metaclass=CompositeFieldBase):
                 self.prefix = '%s_' % name
             for subfield_name, subfield in self.subfields.items():
                 subfield_name = self.prefix + subfield_name
+                verbose_name = subfield.verbose_name
+
+                # If verbose_name is a callable with a single positional
+                # argument or with a parent_verbose_name keyword parameter,
+                # call it with self.verbose_name and update it.
+                if callable(subfield.verbose_name):
+                    try:
+                        subfield.verbose_name = verbose_name(self.verbose_name)
+                    except TypeError:
+                        pass
+
                 subfield.contribute_to_class(cls, subfield_name)
             setattr(cls, name, property(self.get, self.set))
         cls._meta.add_field(self, private=True)

--- a/composite_field/base.py
+++ b/composite_field/base.py
@@ -66,16 +66,14 @@ class CompositeField(object, metaclass=CompositeFieldBase):
                 self.prefix = '%s_' % name
             for subfield_name, subfield in self.subfields.items():
                 subfield_name = self.prefix + subfield_name
-                verbose_name = subfield.verbose_name
 
-                # If verbose_name is a callable with a single positional
-                # argument or with a parent_verbose_name keyword parameter,
-                # call it with self.verbose_name and update it.
-                if callable(subfield.verbose_name):
-                    try:
-                        subfield.verbose_name = verbose_name(self.verbose_name)
-                    except TypeError:
-                        pass
+                if subfield.verbose_name:
+                    # If subfields have a verbose_name set, attempt substitution
+                    # of parent_verbose_name.
+
+                    subfield.verbose_name = subfield.verbose_name % {
+                        "parent_verbose_name": self.verbose_name
+                    }
 
                 subfield.contribute_to_class(cls, subfield_name)
             setattr(cls, name, property(self.get, self.set))

--- a/composite_field/tests.py
+++ b/composite_field/tests.py
@@ -149,12 +149,16 @@ class CompositeFieldTestCase(TestCase):
         place.coord = {'x': 0.0, 'y': 0.0}
         self.assertTrue(place.coord)
 
+    def test_parent_verbose_name(self):
+        get_field = Place._meta.get_field
+        self.assertEqual(str(get_field("coord_y").verbose_name), "coord_verbose yyy")
+
 
 class LocalizedFieldTestCase(TestCase):
-
     def test_general(self):
         foo = LocalizedFoo()
         self.assertEqual(len(LocalizedFoo._meta.fields), 4)
+
         foo.name_de = 'Mr.'
         foo.name_en = 'Herr'
         self.assertEqual(foo.name.de, 'Mr.')

--- a/composite_field_test/models.py
+++ b/composite_field_test/models.py
@@ -7,7 +7,9 @@ from composite_field import ComplexField
 
 class CoordField(CompositeField):
     x = models.FloatField(null=True)
-    y = models.FloatField(null=True)
+    y = models.FloatField(
+        null=True, verbose_name=lambda parent_verbose_name: f"{parent_verbose_name} yyy"
+    )
 
     class Proxy(CompositeField.Proxy):
 
@@ -17,7 +19,7 @@ class CoordField(CompositeField):
 
 class Place(models.Model):
     name = models.CharField(max_length=10)
-    coord = CoordField()
+    coord = CoordField(verbose_name="coord_verbose")
 
 
 class PlaceWithDefaultCoord(models.Model):

--- a/composite_field_test/models.py
+++ b/composite_field_test/models.py
@@ -8,7 +8,7 @@ from composite_field import ComplexField
 class CoordField(CompositeField):
     x = models.FloatField(null=True)
     y = models.FloatField(
-        null=True, verbose_name=lambda parent_verbose_name: f"{parent_verbose_name} yyy"
+        null=True, verbose_name="%(parent_verbose_name)s yyy"
     )
 
     class Proxy(CompositeField.Proxy):

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -90,3 +90,22 @@ It is even possible to replace the ``Proxy`` object entirely and
 return a custom type. A good example for this is the included
 ``ComplexField`` which stores a ``complex`` number in two
 integer fields.
+
+When the ``verbose_name`` on a subfield is callable, it will be called
+with the parent field's ``verbose_name`` so that it can be dynamically set:
+
+.. code-block:: python
+
+    class IntegerEstimatedRange(CompositeField):
+        minimum = models.DurationField(
+            lambda n: _("%(parent_verbose_name)s minimum") % {
+                "parent_verbose_name": n
+            }
+        )
+
+    class Species(models.Model):
+        height = IntegerEstimatedRange(verbose_name=_("plant height"))
+
+This will render the verbose name as 'plant height minimum'. Translations
+and internationalisation will function as expected (e.g. in some locales
+the order may be reversed).

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -91,20 +91,18 @@ return a custom type. A good example for this is the included
 ``ComplexField`` which stores a ``complex`` number in two
 integer fields.
 
-When the ``verbose_name`` on a subfield is callable, it will be called
-with the parent field's ``verbose_name`` so that it can be dynamically set:
+When the ``verbose_name`` is set on a subfield, ``parent_verbose_name``
+will be substituted with the (default) verbose name from the parent field.
 
 .. code-block:: python
 
     class IntegerEstimatedRange(CompositeField):
         minimum = models.DurationField(
-            lambda n: _("%(parent_verbose_name)s minimum") % {
-                "parent_verbose_name": n
-            }
+            verbose_name=_("%(parent_verbose_name)s minimum")
         )
 
     class Species(models.Model):
-        height = IntegerEstimatedRange(verbose_name=_("plant height"))
+        height = IntegerEstimatedRange(verbose_name="plant height")
 
 This will render the verbose name as 'plant height minimum'. Translations
 and internationalisation will function as expected (e.g. in some locales


### PR DESCRIPTION
Allow using parent names to dynamically compose verbose names of subfields, like so:

```python
    class IntegerEstimatedRange(CompositeField):
        minimum = models.DurationField(
            lambda n: _("%(parent_verbose_name)s minimum") % {
                "parent_verbose_name": n
            }
        )

    class Species(models.Model):
        height = IntegerEstimatedRange(verbose_name=_("plant height"))
```

See proposed documentation. Test added for it as well.