### PR TITLE
Handle lazy translation for verbose names in CompositeField

### DIFF
--- a/composite_field/base.py
+++ b/composite_field/base.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from copy import deepcopy
 
 from django.db.models.fields import Field
+from django.utils.functional import lazy, Promise
 
 
 class CompositeFieldBase(type):
@@ -71,9 +72,17 @@ class CompositeField(object, metaclass=CompositeFieldBase):
                     # If subfields have a verbose_name set, attempt substitution
                     # of parent_verbose_name.
 
-                    subfield.verbose_name = subfield.verbose_name % {
-                        "parent_verbose_name": self.verbose_name
-                    }
+                    if isinstance(subfield.verbose_name, Promise):
+                        # If the verbose_name is a lazy translation, we need to
+                        # make sure the substitution happens lazily as well.
+                        subfield.verbose_name = lazy(
+                            lambda v: v % {"parent_verbose_name": self.verbose_name},
+                            str,
+                        )(subfield.verbose_name)
+                    else:
+                        subfield.verbose_name = subfield.verbose_name % {
+                            "parent_verbose_name": self.verbose_name
+                        }
 
                 subfield.contribute_to_class(cls, subfield_name)
             setattr(cls, name, property(self.get, self.set))


### PR DESCRIPTION
When fields declared under a `CompositeField` subclass has declared `verbose_name` labels, the CompositeField alters the actual verbose_name used using a format specifier (`composite_field/base.py` line ~54). For normal strings this fine.

However for translated strings (via gettext_lazy), this doesnt quite work:

```python
from django.utils.translation import gettext_lazy as _
...
class TestField(CompositeField):
    field1 = CharField(
        ...
        verbose_name=_('Field 1 [en]'))
    ...
```

When a form uses this field with defaults (thus having the form rely on model field verbose names), the name of the field is always the one in the default language set no matter the active request language ("Field 1 [en]" in this case if the default django language is set, even if we have actual translations in po/mo files.

This is because  `contribute_to_class` in `CompositeField` is called on app initialization so the string gets frozen to whatever is the default language at the time of initialization. This PR attempts to fix this by lazily performing the substitution when it receives a lazy subfield `verbose_name`